### PR TITLE
Use as default Note's position `u64::MAX` instead of `0`

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -23,7 +23,7 @@ impl From<(Fee, Crossover)> for Note {
         } = crossover;
 
         let note_type = NoteType::Obfuscated;
-        let pos = 0;
+        let pos = u64::MAX;
 
         Note {
             note_type,

--- a/src/fee.rs
+++ b/src/fee.rs
@@ -124,7 +124,7 @@ impl Fee {
     /// Generates a remainder from the fee and the given gas consumed
     pub fn gen_remainder(&self, gas_consumed: u64) -> Remainder {
         // Consuming more gas than the limit provided should never
-        // occur, and it's not responsability of the `Remainder` to do
+        // occur, and it's not responsability of the `Remainder` to
         // check that.
         // Here defensively ensure it's not panicking, capping the gas
         // consumed to the gas limit.

--- a/src/note.rs
+++ b/src/note.rs
@@ -176,8 +176,8 @@ impl Note {
         let value_commitment = (GENERATOR_EXTENDED * value_commitment)
             + (GENERATOR_NUMS_EXTENDED * blinding_factor);
 
-        // Output notes have undefined position
-        let pos = 0;
+        // Output notes have undefined position, equals to u64's MAX value
+        let pos = u64::MAX;
 
         let encrypted_data = match note_type {
             NoteType::Transparent => {


### PR DESCRIPTION
Since `0` is a valid position inside a tree, a `Note` shouldn't have it
as default value. We used `u64::MAX` instead since this value is not
valid as tree's index.

- Fix few nits (comments, unnecessary unwraps)