### PR TITLE
Update CI to be Canon-compatible

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -29,26 +29,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
-
-  test_stable:
-    name: Stable tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release
 
   test_nightly:
     name: Nightly tests
@@ -73,7 +58,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-10-25 # Latest nightly where works.
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
We need a CI that makes sense with the latest
additions of `Canon` trait that we added to our
stack as stated in #31.

So this PR modifies the CI to:
- `stable` toolchain is no longer tested/supported.
- `cargo check` is done in nightly toolchain also.
- `rustfmt` checks are done with a fixed nightly
version due to the chances of a new nightly toolchain
appearing without rustfmt compiling are quite high.

Closes #31 and unblocks #29