### PR TITLE
Crossover/Fee blinding factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.2] - 06-01-21
 ### Added
 - API to decrypt value and blinding factor from a crossover
+- Note::new is not part of the public API
+- Blinding factor should be returned when creating obfuscated note
 
 ## [0.5.1] - 06-01-21
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.2] - 06-01-21
+## [0.6.0] - 06-01-21
 ### Added
 - API to decrypt value and blinding factor from a crossover
 - Note::new is not part of the public API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - API to decrypt value and blinding factor from a crossover
 - Note::new is not part of the public API
-- Blinding factor should be returned when creating obfuscated note
+- Blinding factor should be returned when creating a note
 
 ## [0.5.1] - 06-01-21
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 06-01-21
+### Added
+- API to decrypt value and blinding factor from a crossover
+
 ## [0.5.1] - 06-01-21
 ### Fix
 - #41 - Wrong value commitment for transparent notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 

--- a/src/note.rs
+++ b/src/note.rs
@@ -93,14 +93,16 @@ impl Note {
         rng: &mut R,
         psk: &PublicSpendKey,
         value: u64,
-    ) -> Self {
+    ) -> (Self, JubJubScalar) {
         // Blinding factor and value commitment are open for transparent note.
         // In order to save storage, these may not be stored and should be
         // hardcoded for an eventual proof of knowledge of the
         // commitment
         let blinding_factor = JubJubScalar::zero();
+        let note =
+            Self::new(rng, NoteType::Transparent, psk, value, blinding_factor);
 
-        Self::new(rng, NoteType::Transparent, psk, value, blinding_factor)
+        (note, blinding_factor)
     }
 
     /// Creates a new obfuscated note
@@ -403,12 +405,13 @@ impl Note {
         rng: &mut R,
         remainder: Remainder,
         psk: &PublicSpendKey,
-    ) -> Self {
-        let mut note = Note::transparent(rng, psk, remainder.gas_changes);
+    ) -> (Self, JubJubScalar) {
+        let (mut note, blinding_factor) =
+            Note::transparent(rng, psk, remainder.gas_changes);
 
         note.stealth_address = remainder.stealth_address;
 
-        note
+        (note, blinding_factor)
     }
 }
 

--- a/tests/note_test.rs
+++ b/tests/note_test.rs
@@ -19,7 +19,7 @@ fn transparent_note() -> Result<(), Error> {
     let psk = ssk.public_key();
     let value = 25;
 
-    let note = Note::transparent(rng, &psk, value);
+    let (note, _) = Note::transparent(rng, &psk, value);
 
     assert_eq!(note.note(), NoteType::Transparent);
     assert_eq!(value, note.value(None)?);
@@ -81,16 +81,18 @@ fn value_commitment_transparent() {
     let psk = ssk.public_key();
     let value = 25;
 
-    let note = Note::transparent(rng, &psk, value);
+    let (note, blinding_factor) = Note::transparent(rng, &psk, value);
 
     let value = note
         .value(Some(&vsk))
         .expect("Value not returned with the correct view key");
     let value = JubJubScalar::from(value);
 
-    let blinding_factor = note
+    let blinding_factor_p = note
         .blinding_factor(Some(&vsk))
         .expect("Blinding factor not returned with the correct view key");
+
+    assert_eq!(blinding_factor, blinding_factor_p);
 
     let commitment = note.value_commitment();
     let commitment_p = (GENERATOR_EXTENDED * value)
@@ -221,7 +223,7 @@ fn fail_fee_and_crossover_from_transparent() -> Result<(), Error> {
     let psk = ssk.public_key();
     let value = 25;
 
-    let note = Note::transparent(rng, &psk, value);
+    let (note, _) = Note::transparent(rng, &psk, value);
     let result: Result<(Fee, Crossover), Error> = note.try_into();
 
     assert_matches!(
@@ -247,7 +249,7 @@ fn transparent_from_fee_remainder() -> Result<(), Error> {
 
     let fee = Fee::new(rng, gas_limit, gas_price, &psk);
     let remainder = fee.gen_remainder(gas_consumed);
-    let note = Note::from_remainder(rng, remainder, &psk);
+    let (note, _) = Note::from_remainder(rng, remainder, &psk);
 
     assert_eq!(note.stealth_address(), fee.stealth_address());
     assert_eq!(
@@ -272,7 +274,7 @@ fn transparent_from_fee_remainder_with_invalid_consumed() -> Result<(), Error> {
 
     let fee = Fee::new(rng, gas_limit, gas_price, &psk);
     let remainder = fee.gen_remainder(gas_consumed);
-    let note = Note::from_remainder(rng, remainder, &psk);
+    let (note, _) = Note::from_remainder(rng, remainder, &psk);
 
     assert_eq!(note.stealth_address(), fee.stealth_address());
     assert_eq!(note.value(Some(&vk))?, 0);


### PR DESCRIPTION
### Blinding factor returned when create transp note

The blinding factor is a required return of the obfuscated note creation.

To maintain API consistency, the creation of the transparent note should return the blinding factor as well.

It happens to be constant zero. But, to keep this logic decoupled from the consumers of this library, and if ever this constant changes, its logic is now granted to be defined only inside of phoenix-core

###  Blinder should be returned when create obfuscated

Note::new is not part of the API because it is expected the note is created either via `Note::transparent` or `Note::obfuscated`.

The blinding factor must be returned when the note is created as obfuscated because the creator of an eventual output will not be able to decrypt it according to the properties of asymmetric encryption