### PR TITLE
Blinding factor as parameter of Note::obfuscated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 07-01-21
 ### Changed
 - Blinding factor provided to create obfuscated notes
-- Transparent note with constant blinding factor
 
 ## [0.5.1] - 06-01-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 07-01-21
+### Changed
+- Blinding factor provided to create obfuscated notes
+- Transparent note with constant blinding factor
+
 ## [0.5.1] - 06-01-21
-### Fix
+### Fixed
 - #41 - Wrong value commitment for transparent notes
 
 ## [0.5.0] - 27-11-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 

--- a/tests/note_test.rs
+++ b/tests/note_test.rs
@@ -36,7 +36,8 @@ fn obfuscated_note() -> Result<(), Error> {
     let vk = ssk.view_key();
     let value = 25;
 
-    let note = Note::obfuscated(rng, &psk, value);
+    let blinding_factor = JubJubScalar::random(rng);
+    let note = Note::obfuscated(rng, &psk, value, blinding_factor);
 
     assert_eq!(note.note(), NoteType::Obfuscated);
     assert_eq!(value, note.value(Some(&vk))?);
@@ -108,7 +109,8 @@ fn value_commitment_obfuscated() {
     let psk = ssk.public_key();
     let value = 25;
 
-    let note = Note::obfuscated(rng, &psk, value);
+    let blinding_factor = JubJubScalar::random(rng);
+    let note = Note::obfuscated(rng, &psk, value, blinding_factor);
 
     let value = note
         .value(Some(&vsk))
@@ -141,7 +143,8 @@ fn note_keys_consistency() {
     assert_ne!(ssk, wrong_ssk);
     assert_ne!(vk, wrong_vk);
 
-    let note = Note::obfuscated(rng, &psk, value);
+    let blinding_factor = JubJubScalar::random(rng);
+    let note = Note::obfuscated(rng, &psk, value, blinding_factor);
 
     assert!(!wrong_vk.owns(&note));
     assert!(vk.owns(&note));
@@ -156,7 +159,8 @@ fn fee_and_crossover_generation() -> Result<(), Error> {
     let vk = ssk.view_key();
     let value = 25;
 
-    let note = Note::obfuscated(rng, &psk, value);
+    let blinding_factor = JubJubScalar::random(rng);
+    let note = Note::obfuscated(rng, &psk, value, blinding_factor);
     let (fee, crossover): (Fee, Crossover) = note.try_into()?;
 
     let ssk_fee = SecretSpendKey::random(rng);


### PR DESCRIPTION
The blinding factor is required to prove the knowledge of the value commitment of the note.

If the blinding factor is not provided by the note creator, the latter will not be able to fetch this information, and consequentially create a zk proof of knowledge of the value commitment, without the view key of the owner of the note.

This is not desirable since a note should be created only with the public key of the receiver.