### PR TITLE
Update `phoenix-core` lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 07-01-21
+## [0.7.0] - 2021-01-07
+
+### Added
+
+- Add `dusk_bytes::Serializable` trait to `Note`, `Fee` and `Crossover`
+
+### Removed
+
+- Remove manual implementation of `to_bytes` and `from_bytes`
+
 ### Changed
+
+- Bump `canonical` to `v0.5`
+- Bump `dusk-bls12_381` to v0.6
+- Bump `dusk-jubjub` to `v0.8`
+- Bump `poseidon252` to `v0.16.0`
+- Bump `dusk-pki` to `v0.5`
+- Update CHANGELOG to ISO 8601
+
+## [0.6.0] - 2021-01-07
+
+### Changed
+
 - Blinding factor provided to create obfuscated notes
 
-## [0.5.1] - 06-01-21
+## [0.5.1] - 2021-01-06
+
 ### Fixed
+
 - #41 - Wrong value commitment for transparent notes
 
-## [0.5.0] - 27-11-20
+## [0.5.0] - 2020-11-27
+
 ### Added
+
 - To/From bytes impl for `Fee` & `Crossover`.
 
-## [0.5.0-alpha] - 27-11-20
+## [0.5.0-alpha] - 2020-11-27
+
 ### Changed
+
 - No-Std compatibility.
 - Removal of anyhow error implementation.
 - Canonical implementation shielded by feature.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "phoenix-core"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 
 [dependencies]
-rand_core = "0.5.1"
-dusk-bls12_381 = {version = "0.3", default-features = false}
-dusk-jubjub = {version = "0.5", default-features = false}
-poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.15.0", default-features = false}
-dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.4.1", default-features = false}
-canonical = {version = "0.4", optional = true}
-canonical_derive = {version = "0.4", optional = true}
+rand_core = "0.5"
+dusk-bls12_381 = {version = "0.6", default-features = false}
+dusk-jubjub = {version = "0.8", default-features = false}
+poseidon252 = {git = "https://github.com/dusk-network/Poseidon252", tag = "v0.16.0", default-features = false}
+dusk-pki = {git = "https://github.com/dusk-network/dusk-pki", tag = "v0.5.0", default-features = false}
+canonical = {version = "0.5", optional = true}
+canonical_derive = {version = "0.5", optional = true}
+dusk-bytes = "0.1"
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/src/crossover.rs
+++ b/src/crossover.rs
@@ -6,15 +6,15 @@
 
 //! Fee module contains the logic related to `Crossover` structure
 
-use crate::{BlsScalar, Error, JubJubExtended, JubJubScalar};
+use crate::{BlsScalar, JubJubExtended, JubJubScalar};
 
 #[cfg(feature = "canon")]
 use canonical::Canon;
 #[cfg(feature = "canon")]
 use canonical_derive::Canon;
 
+use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::JubJubAffine;
-use dusk_pki::jubjub_decode;
 use poseidon252::cipher::PoseidonCipher;
 use poseidon252::sponge::hash;
 
@@ -35,12 +35,39 @@ impl PartialEq for Crossover {
 
 impl Eq for Crossover {}
 
-impl Crossover {
-    /// Returns the serialized size of the Crossover
-    pub const fn serialized_size() -> usize {
-        32 * 2 + PoseidonCipher::cipher_size_bytes()
+impl Serializable<{ 64 + PoseidonCipher::SIZE }> for Crossover {
+    type Error = BytesError;
+
+    /// Converts a Crossover into it's byte representation
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut buf = [0u8; Self::SIZE];
+
+        buf[..32].copy_from_slice(
+            &JubJubAffine::from(&self.value_commitment).to_bytes(),
+        );
+        buf[32..64].copy_from_slice(&self.nonce.to_bytes());
+        buf[64..].copy_from_slice(&self.encrypted_data.to_bytes());
+        buf
     }
 
+    /// Attempts to convert a byte representation of a note into a `Note`,
+    /// failing if the input is invalid
+    fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        let value_commitment =
+            JubJubExtended::from(JubJubAffine::from_slice(&bytes[..32])?);
+        let nonce = JubJubScalar::from_slice(&bytes[32..])?;
+
+        let encrypted_data = PoseidonCipher::from_slice(&bytes[64..])?;
+
+        Ok(Crossover {
+            value_commitment,
+            nonce,
+            encrypted_data,
+        })
+    }
+}
+
+impl Crossover {
     /// Returns a hash represented by `H(value_commitment)`
     pub fn hash(&self) -> BlsScalar {
         let value_commitment = self.value_commitment().to_hash_inputs();
@@ -61,61 +88,5 @@ impl Crossover {
     /// Returns the encrypted data
     pub fn encrypted_data(&self) -> &PoseidonCipher {
         &self.encrypted_data
-    }
-
-    /// Converts a Crossover into it's byte representation
-    pub fn to_bytes(&self) -> [u8; Crossover::serialized_size()] {
-        let mut buf = [0u8; Crossover::serialized_size()];
-        let mut n = 0;
-
-        buf[n..n + 32].copy_from_slice(
-            &JubJubAffine::from(&self.value_commitment).to_bytes()[..],
-        );
-        n += 32;
-
-        buf[n..n + 32].copy_from_slice(&self.nonce.to_bytes()[..]);
-        n += 32;
-
-        buf[n..n + PoseidonCipher::cipher_size_bytes()]
-            .copy_from_slice(&self.encrypted_data.to_bytes()[..]);
-        n += PoseidonCipher::cipher_size_bytes();
-
-        debug_assert_eq!(n, Crossover::serialized_size());
-
-        buf
-    }
-
-    /// Attempts to convert a byte representation of a note into a `Note`,
-    /// failing if the input is invalid
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        if bytes.len() < Crossover::serialized_size() {
-            return Err(Error::InvalidCrossoverConversion);
-        }
-
-        let mut bytes_32 = [0u8; 32];
-        let mut one_cipher = [0u8; PoseidonCipher::cipher_size_bytes()];
-
-        let mut n = 0;
-
-        bytes_32.copy_from_slice(&bytes[n..n + 32]);
-        let value_commitment =
-            JubJubExtended::from(jubjub_decode::<JubJubAffine>(&bytes_32)?);
-        n += 32;
-
-        bytes_32.copy_from_slice(&bytes[n..n + 32]);
-        let nonce = jubjub_decode::<JubJubScalar>(&bytes_32)?;
-        n += 32;
-
-        one_cipher.copy_from_slice(
-            &bytes[n..n + PoseidonCipher::cipher_size_bytes()],
-        );
-        let encrypted_data = PoseidonCipher::from_bytes(&one_cipher)
-            .ok_or(Error::InvalidCipher)?;
-
-        Ok(Crossover {
-            value_commitment,
-            nonce,
-            encrypted_data,
-        })
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,6 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_pki::Error as PkiError;
 use poseidon252::Error as PoseidonError;
 
 use core::fmt;
@@ -27,16 +26,8 @@ pub enum Error {
     InvalidCrossoverConversion,
     /// Invalid Fee for conversion
     InvalidFeeConversion,
-    /// Dusk-Pki Error
-    PKIError(PkiError),
     /// Poseidon Error
     PoseidonError,
-}
-
-impl From<PkiError> for Error {
-    fn from(e: PkiError) -> Error {
-        Error::PKIError(e)
-    }
 }
 
 impl<E: fmt::Debug> From<PoseidonError<E>> for Error {

--- a/src/fee/remainder.rs
+++ b/src/fee/remainder.rs
@@ -39,7 +39,7 @@ impl Eq for Remainder {}
 impl Remainder {
     /// Return a hash represented by `H(gas, H([pskr]))`
     pub fn hash(&self) -> BlsScalar {
-        let pk_r = self.stealth_address().pk_r().to_hash_inputs();
+        let pk_r = self.stealth_address().pk_r().as_ref().to_hash_inputs();
 
         hash(&[BlsScalar::from(self.gas_changes), pk_r[0], pk_r[1]])
     }

--- a/tests/note_test.rs
+++ b/tests/note_test.rs
@@ -16,7 +16,7 @@ fn transparent_note() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -32,7 +32,7 @@ fn obfuscated_note() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -50,7 +50,7 @@ fn obfuscated_deterministic_note() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -79,7 +79,7 @@ fn value_commitment_transparent() {
 
     let ssk = SecretSpendKey::random(rng);
     let vsk = ssk.view_key();
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -106,7 +106,7 @@ fn value_commitment_obfuscated() {
 
     let ssk = SecretSpendKey::random(rng);
     let vsk = ssk.view_key();
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let value = 25;
 
     let blinding_factor = JubJubScalar::random(rng);
@@ -133,7 +133,7 @@ fn note_keys_consistency() {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -155,7 +155,7 @@ fn fee_and_crossover_generation() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
     let value = 25;
 
@@ -170,7 +170,7 @@ fn fee_and_crossover_generation() -> Result<(), Error> {
     assert_ne!(note, wrong_note);
     assert_matches!(
         wrong_note.value(Some(&vk)),
-        Err(Error::PoseidonError),
+        Err(Error::InvalidCipher),
         "Expected to fail the decryption of the cipher"
     );
 
@@ -186,7 +186,7 @@ fn fail_fee_and_crossover_from_transparent() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let value = 25;
 
     let note = Note::transparent(rng, &psk, value);
@@ -206,7 +206,7 @@ fn transparent_from_fee_remainder() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
 
     let gas_consumed = 3;
@@ -231,7 +231,7 @@ fn transparent_from_fee_remainder_with_invalid_consumed() -> Result<(), Error> {
     let rng = &mut rand::thread_rng();
 
     let ssk = SecretSpendKey::random(rng);
-    let psk = ssk.public_key();
+    let psk = ssk.public_spend_key();
     let vk = ssk.view_key();
 
     let gas_consumed = 30;


### PR DESCRIPTION
- Add `dusk_bytes::Serializable` trait to `Note`, `Fee` and `Crossover`
- Remove manual implementation of `to_bytes` and `from_bytes`
- Bump `canonical` to `v0.5`
- Bump `dusk-bls12_381` to v0.6
- Bump `dusk-jubjub` to `v0.8`
- Bump `poseidon252` to `v0.16.0`
- Bump `dusk-pki` to `v0.5`
- Update CHANGELOG to ISO 8601

Resolves: #50