### PR TITLE
Closes #65 - Fee - Out of gas exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2021-02-19
+
+### Changed
+
+- Fee - Out of gas exceptions [#65](https://github.com/dusk-network/phoenix-core/issues/65)
+- Remainder - Generate note from consumed gas
+- Note - Create transparent note from stealth address
+
 ## [0.9.1] - 2021-02-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -4,13 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::note::TRANSPARENT_BLINDER;
-use crate::{BlsScalar, JubJubScalar};
-use crate::{Crossover, Error, Fee, Note, NoteType, Remainder};
-
-use core::convert::TryFrom;
-use dusk_jubjub::{GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED};
-use dusk_poseidon::cipher::PoseidonCipher;
+use crate::{Crossover, Fee, Note, NoteType};
 
 impl From<(Fee, Crossover)> for Note {
     fn from((fee, crossover): (Fee, Crossover)) -> Note {
@@ -26,73 +20,6 @@ impl From<(Fee, Crossover)> for Note {
 
         let note_type = NoteType::Obfuscated;
         let pos = u64::MAX;
-
-        Note {
-            note_type,
-            value_commitment,
-            nonce,
-            stealth_address,
-            pos,
-            encrypted_data,
-        }
-    }
-}
-
-impl TryFrom<Note> for (Fee, Crossover) {
-    type Error = Error;
-
-    fn try_from(note: Note) -> Result<Self, Self::Error> {
-        match note.note_type {
-            NoteType::Obfuscated => {
-                let gas_limit = 0;
-                let gas_price = 0;
-                let Note {
-                    stealth_address,
-                    value_commitment,
-                    nonce,
-                    encrypted_data,
-                    ..
-                } = note;
-
-                Ok((
-                    Fee {
-                        gas_limit,
-                        gas_price,
-                        stealth_address,
-                    },
-                    Crossover {
-                        value_commitment,
-                        nonce,
-                        encrypted_data,
-                    },
-                ))
-            }
-            _ => Err(Error::InvalidNoteConversion),
-        }
-    }
-}
-
-impl From<Remainder> for Note {
-    fn from(remainder: Remainder) -> Note {
-        let note_type = NoteType::Transparent;
-        let pos = u64::MAX;
-
-        let stealth_address = remainder.stealth_address;
-        let value = remainder.gas_changes;
-        let nonce = JubJubScalar::zero();
-
-        let value_commitment = JubJubScalar::from(value);
-        let value_commitment = (GENERATOR_EXTENDED * value_commitment)
-            + (GENERATOR_NUMS_EXTENDED * TRANSPARENT_BLINDER);
-
-        let encrypted_data = {
-            let zero = TRANSPARENT_BLINDER.into();
-            let mut encrypted_data = [zero; PoseidonCipher::cipher_size()];
-
-            encrypted_data[0] = BlsScalar::from(value);
-
-            PoseidonCipher::new(encrypted_data)
-        };
 
         Note {
             note_type,

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     InvalidCommitment,
     /// Invalid Nonce
     InvalidNonce,
+    /// Remainder is out of gas
+    OutOfGas,
 }
 
 impl<E: fmt::Debug> From<PoseidonError<E>> for Error {


### PR DESCRIPTION
Closes #65 

Prior to this commit, no gas limit or gas consumed validations were
performed. This can lead to several bugs in phoenix implementations, and
there is no reason to not perform the checks in this library since it
contains all the required data for every validation.

Also, a consumed fee note will need to be created from a given stealth
address to a block generator. Prior to this commit, the API will not
allow note creation with a specific stealth address without the
knowledge of `r`.