### PR TITLE
crossover: use all attributes as hash inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Crossover: use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
+
 ## [0.10.0] - 2021-04-06
 
 ### Changed

--- a/src/crossover.rs
+++ b/src/crossover.rs
@@ -16,7 +16,7 @@ use canonical_derive::Canon;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::JubJubAffine;
 use dusk_poseidon::cipher::PoseidonCipher;
-use dusk_poseidon::sponge::hash;
+use dusk_poseidon::sponge;
 
 /// Crossover structure containing obfuscated encrypted data
 #[derive(Clone, Copy, Debug, Default)]
@@ -68,25 +68,37 @@ impl Serializable<{ 64 + PoseidonCipher::SIZE }> for Crossover {
 }
 
 impl Crossover {
-    /// Returns a hash represented by `H(value_commitment)`
-    pub fn hash(&self) -> BlsScalar {
-        let value_commitment = self.value_commitment().to_hash_inputs();
+    /// Represent the crossover as a sequence of scalars to be used as input for
+    /// sponge hash functions
+    pub fn to_hash_inputs(
+        &self,
+    ) -> [BlsScalar; 3 + PoseidonCipher::cipher_size()] {
+        let mut inputs = [BlsScalar::zero(); 3 + PoseidonCipher::cipher_size()];
 
-        hash(&value_commitment)
+        inputs[0..2].copy_from_slice(&self.value_commitment().to_hash_inputs());
+        inputs[2] = self.nonce.into();
+        inputs[3..].copy_from_slice(self.encrypted_data.cipher());
+
+        inputs
+    }
+
+    /// Sponge hash of the crossover hash inputs representation
+    pub fn hash(&self) -> BlsScalar {
+        sponge::hash(&self.to_hash_inputs())
     }
 
     /// Returns the Nonce used for the encrypt / decrypt of data for this note
-    pub fn nonce(&self) -> &JubJubScalar {
+    pub const fn nonce(&self) -> &JubJubScalar {
         &self.nonce
     }
 
     /// Returns the value commitment `H(value, blinding_factor)`
-    pub fn value_commitment(&self) -> &JubJubExtended {
+    pub const fn value_commitment(&self) -> &JubJubExtended {
         &self.value_commitment
     }
 
     /// Returns the encrypted data
-    pub fn encrypted_data(&self) -> &PoseidonCipher {
+    pub const fn encrypted_data(&self) -> &PoseidonCipher {
         &self.encrypted_data
     }
 }

--- a/tests/crossover.rs
+++ b/tests/crossover.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use core::convert::TryInto;
+
+use dusk_jubjub::JubJubScalar;
+use dusk_pki::SecretSpendKey;
+use phoenix_core::{Error, Note};
+
+#[test]
+fn crossover_hash() -> Result<(), Error> {
+    let rng = &mut rand::thread_rng();
+
+    let ssk = SecretSpendKey::random(rng);
+    let psk = ssk.public_spend_key();
+
+    let value = 25;
+    let blinding_factor = JubJubScalar::random(rng);
+    let note = Note::obfuscated(rng, &psk, value, blinding_factor);
+
+    let value = 25;
+    let blinding_factor = JubJubScalar::random(rng);
+    let note_p = Note::obfuscated(rng, &psk, value, blinding_factor);
+
+    let (_, crossover) = note.try_into()?;
+    let (_, crossover_p) = note_p.try_into()?;
+
+    let hash = crossover.hash();
+    let hash_p = crossover_p.hash();
+
+    assert_ne!(hash, hash_p);
+
+    Ok(())
+}


### PR DESCRIPTION
The hash representation of the crossover should reflect all the
attributes.

Even if the crossover is composed only by `value` and `blinder`, and
both are present in the value commitment, its hash representation should
also guarantee the consistency of the whole object. This way, we
increase the overall security of the system.

Resolves #69