### PR TITLE
message: use attributes as hash inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Crossover: use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
+- Message: use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
 
 ## [0.10.0] - 2021-04-06
 

--- a/tests/crossover.rs
+++ b/tests/crossover.rs
@@ -8,7 +8,7 @@ use core::convert::TryInto;
 
 use dusk_jubjub::JubJubScalar;
 use dusk_pki::SecretSpendKey;
-use phoenix_core::{Error, Note};
+use phoenix_core::{Error, Note, Message};
 
 #[test]
 fn crossover_hash() -> Result<(), Error> {
@@ -30,6 +30,28 @@ fn crossover_hash() -> Result<(), Error> {
 
     let hash = crossover.hash();
     let hash_p = crossover_p.hash();
+
+    assert_ne!(hash, hash_p);
+
+    Ok(())
+}
+
+#[test]
+fn message_hash() -> Result<(), Error> {
+    let rng = &mut rand::thread_rng();
+
+    let ssk = SecretSpendKey::random(rng);
+    let psk = ssk.public_spend_key();
+    let value = 25;
+
+    let r = JubJubScalar::random(rng);
+    let message = Message::new(rng, &r, &psk, value);
+
+    let r_p = JubJubScalar::random(rng);
+    let message_p = Message::new(rng, &r_p, &psk, value);
+
+    let hash = message.hash();
+    let hash_p = message_p.hash();
 
     assert_ne!(hash, hash_p);
 

--- a/tests/crossover.rs
+++ b/tests/crossover.rs
@@ -8,7 +8,7 @@ use core::convert::TryInto;
 
 use dusk_jubjub::JubJubScalar;
 use dusk_pki::SecretSpendKey;
-use phoenix_core::{Error, Note, Message};
+use phoenix_core::{Error, Message, Note};
 
 #[test]
 fn crossover_hash() -> Result<(), Error> {


### PR DESCRIPTION
The message structure follows the same pattern as crossover. It must
implement the same hashing strategies.

Resolves #69