### PR TITLE
Change note position to reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Crossover: use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
 - Message: use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
 - Update `canonical` from `v0.5` to `v0.6` [#72](https://github.com/dusk-network/phoenix-core/issues/72)
+- Change note position to reference [#76](https://github.com/dusk-network/phoenix-core/issues/76)
 
 ## [0.10.0] - 2021-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 rand_core = "0.6"
 dusk-bytes = "0.1"
-dusk-bls12_381 = {version="0.8.0-rc", default-features=false}
-dusk-jubjub = {version="0.10.0-rc", default-features=false}
+dusk-bls12_381 = {version="0.8", default-features=false}
+dusk-jubjub = {version="0.10", default-features=false}
 dusk-poseidon = {version="0.21.0-rc", default-features=false}
 dusk-pki = {version="0.7.0-rc", default-features=false}
 canonical = {version="0.6", optional=true}

--- a/src/note.rs
+++ b/src/note.rs
@@ -197,7 +197,7 @@ impl Note {
     pub fn gen_nullifier(&self, sk: &SecretSpendKey) -> BlsScalar {
         let sk_r = sk.sk_r(&self.stealth_address);
         let sk_r = BlsScalar::from(*sk_r.as_ref());
-        let pos = BlsScalar::from(self.pos());
+        let pos = BlsScalar::from(self.pos);
 
         hash(&[sk_r, pos])
     }
@@ -218,7 +218,7 @@ impl Note {
             pk_r[1],
             R[0],
             R[1],
-            BlsScalar::from(self.pos()),
+            BlsScalar::from(self.pos),
             cipher[0],
             cipher[1],
             cipher[2],
@@ -237,8 +237,8 @@ impl Note {
     }
 
     /// Return the position of the note on the tree.
-    pub fn pos(&self) -> u64 {
-        self.pos
+    pub fn pos(&self) -> &u64 {
+        &self.pos
     }
 
     /// Set the position of the note on the tree.


### PR DESCRIPTION
`dusk-poseidon 0.21` brought a change to use the position as reference
to optimize usage in environments *32 such as WASM.

Resolves #76