### PR TITLE
Change `rand_core` to not use default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Message` to use all attributes as hash inputs [#69](https://github.com/dusk-network/phoenix-core/issues/69)
 - Update `canonical` from `v0.5` to `v0.6` [#72](https://github.com/dusk-network/phoenix-core/issues/72)
 - Change note position to reference [#76](https://github.com/dusk-network/phoenix-core/issues/76)
+- Change `rand_core` to not use default features [#80](https://github.com/dusk-network/phoenix-core/issues/80)
 
 ## [0.10.0] - 2021-04-06
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 exclude = [".github/workflows/ci.yml", ".gitignore"]
 
 [dependencies]
-rand_core = "0.6"
+rand_core = { version = "0.6", default-features = false }
 dusk-bytes = "0.1"
 dusk-bls12_381 = { version = "0.8", default-features = false }
 dusk-jubjub = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.11.0-rc.0"
+version = "0.11.0-rc.1"
 authors = ["zer0 <matteo@dusk.network>", "Victor Lopez <victor@dusk.network"]
 edition = "2018"
 repository = "https://github.com/dusk-network/phoenix-core"


### PR DESCRIPTION
The default features of `rand_core` will pull `getrandom` that relies on
`std`.

Since `phoenix-core` is `no-std`, this would lead to major
inconsistencies on the contracts layer.

Resolves #80