### PR TITLE
Add From<Error> impl for dusk-bytes::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `dusk-bytes::BadLength` impl for crate Error [#88](https://github.com/dusk-network/phoenix-core/issues/88)
-
+- Add `From<Error>` impl for `dusk-bytes::Error` [#92](https://github.com/dusk-network/phoenix-core/issues/92)
 ### Changed
 
 - Change `JubJubScalar` for `BlsScalar` for all `nonce` attributes. [#84](https://github.com/dusk-network/phoenix-core/issues/84)

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bytes::BadLength;
+use dusk_bytes::{BadLength, Error as DuskBytesError, InvalidChar};
 use dusk_poseidon::Error as PoseidonError;
 
 use core::fmt;
@@ -33,8 +33,12 @@ pub enum Error {
     InvalidCommitment,
     /// Invalid Nonce
     InvalidNonce,
+    /// Dusk-bytes InvalidData error
+    InvalidData,
     /// Dusk-bytes BadLenght error
     BadLenght(usize, usize),
+    /// Dusk-bytes InvalidChar error
+    InvalidChar(char, usize),
 }
 
 impl From<PoseidonError> for Error {
@@ -49,8 +53,29 @@ impl fmt::Display for Error {
     }
 }
 
+impl From<Error> for DuskBytesError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::InvalidData => DuskBytesError::InvalidData,
+            Error::BadLenght(found, expected) => {
+                DuskBytesError::BadLength { found, expected }
+            }
+            Error::InvalidChar(ch, index) => {
+                DuskBytesError::InvalidChar { ch, index }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl BadLength for Error {
     fn bad_length(found: usize, expected: usize) -> Self {
         Error::BadLenght(found, expected)
+    }
+}
+
+impl InvalidChar for Error {
+    fn invalid_char(ch: char, index: usize) -> Self {
+        Error::InvalidChar(ch, index)
     }
 }


### PR DESCRIPTION
This was needed so that we can use `?` inside of Serializable impls
without needing to map errors on libs that depend on structures of this
one.

Resolves: #92