### PR TITLE
Update nullifier to hash of pk'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update nullifier to hash of pk' [#96]
+
 ## [0.13.0] - 2021-07-27
 
 ### Changed
@@ -137,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removal of anyhow error implementation.
 - Canonical implementation shielded by feature.
 
+[#96]: https://github.com/dusk-network/phoenix-core/issues/96
 [#94]: https://github.com/dusk-network/phoenix-core/issues/94
 [#92]: https://github.com/dusk-network/phoenix-core/issues/92
 [#88]: https://github.com/dusk-network/phoenix-core/issues/88

--- a/src/note.rs
+++ b/src/note.rs
@@ -193,12 +193,16 @@ impl Note {
     }
 
     /// Create a unique nullifier for the note
+    ///
+    /// This nullifier is represeted as `H(sk_r · G', pos)`
     pub fn gen_nullifier(&self, sk: &SecretSpendKey) -> BlsScalar {
         let sk_r = sk.sk_r(&self.stealth_address);
-        let sk_r = BlsScalar::from(*sk_r.as_ref());
+        let pk_prime = GENERATOR_NUMS_EXTENDED * sk_r.as_ref();
+        let pk_prime = pk_prime.to_hash_inputs();
+
         let pos = BlsScalar::from(self.pos);
 
-        hash(&[sk_r, pos])
+        hash(&[pk_prime[0], pk_prime[1], pos])
     }
 
     /// Return the internal representation of scalars to be hashed


### PR DESCRIPTION
The new nullifier formula is `H(pk_r', pos)`. It will interact with
schnorr signatures to prevent transaction malleability.

Resolves #96