### PR TITLE
Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.85"
 license = "MPL-2.0"
+edition = "2024"

--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move to edition 2024
 - Move to stable MSRV 1.85
 - Update `dusk-plonk` to v0.22.0-rc.0
 - Update `poseidon-merkle` to v0.9.0-rc.0

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "phoenix-circuits"
 version = "0.6.0"
-edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 license.workspace = true
 rust-version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/circuits/src/circuit_impl.rs
+++ b/circuits/src/circuit_impl.rs
@@ -15,7 +15,7 @@ use dusk_poseidon::{Domain, HashGadget};
 use jubjub_schnorr::gadgets;
 use poseidon_merkle::zk::opening_gadget;
 
-use crate::{sender_enc, InputNoteInfo, TxCircuit};
+use crate::{InputNoteInfo, TxCircuit, sender_enc};
 
 impl<const H: usize, const I: usize> Circuit for TxCircuit<H, I> {
     /// Transaction gadget proving the following properties in ZK for a generic

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -19,12 +19,12 @@ use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::{JubJubAffine, JubJubScalar};
 use jubjub_schnorr::{Signature as SchnorrSignature, SignatureDouble};
-use poseidon_merkle::{Item, Opening, Tree, ARITY};
+use poseidon_merkle::{ARITY, Item, Opening, Tree};
 
 #[cfg(feature = "rkyv-impl")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use phoenix_core::{Note, PublicKey, SecretKey, OUTPUT_NOTES};
+use phoenix_core::{Note, OUTPUT_NOTES, PublicKey, SecretKey};
 
 extern crate alloc;
 use alloc::vec::Vec;

--- a/circuits/src/sender_enc.rs
+++ b/circuits/src/sender_enc.rs
@@ -8,8 +8,8 @@
 
 use dusk_jubjub::JubJubAffine;
 use dusk_plonk::prelude::*;
-use jubjub_schnorr::{gadgets, Signature as SchnorrSignature};
-use phoenix_core::{PublicKey, OUTPUT_NOTES};
+use jubjub_schnorr::{Signature as SchnorrSignature, gadgets};
+use phoenix_core::{OUTPUT_NOTES, PublicKey};
 
 use jubjub_elgamal::zk::Encryption as ElGamalZK;
 

--- a/circuits/tests/serialization.rs
+++ b/circuits/tests/serialization.rs
@@ -115,8 +115,8 @@ fn random_circuit<const I: usize>(
         ],
         payload_hash: BlsScalar::random(&mut *rng),
         root: BlsScalar::random(&mut *rng),
-        deposit: rng.gen(),
-        max_fee: rng.gen(),
+        deposit: rng.r#gen(),
+        max_fee: rng.r#gen(),
         sender_pk,
         signatures: (
             SchnorrSignature::from_bytes(&signature_0_bytes)
@@ -168,7 +168,7 @@ fn random_input_note_info(
         merkle_opening,
         note,
         note_pk_p,
-        value: rng.gen(),
+        value: rng.r#gen(),
         value_blinder: JubJubScalar::random(&mut *rng),
         nullifier: BlsScalar::random(&mut *rng),
         signature: SignatureDouble::from_bytes(&signature_bytes)
@@ -188,7 +188,7 @@ fn random_output_note_info(
     let sender_enc_1_1 = random_jubjub_affine(rng);
 
     OutputNoteInfo {
-        value: rng.gen(),
+        value: rng.r#gen(),
         value_commitment,
         value_blinder: JubJubScalar::random(&mut *rng),
         note_pk,

--- a/circuits/tests/serialization.rs
+++ b/circuits/tests/serialization.rs
@@ -4,13 +4,13 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use rand::{CryptoRng, Rng, RngCore};
 
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{Error as BytesError, Serializable};
-use dusk_jubjub::{JubJubAffine, JubJubScalar, GENERATOR_EXTENDED};
+use dusk_jubjub::{GENERATOR_EXTENDED, JubJubAffine, JubJubScalar};
 use ff::Field;
 use jubjub_schnorr::{Signature as SchnorrSignature, SignatureDouble};
 use poseidon_merkle::{Item, Tree};

--- a/circuits/tests/transaction.rs
+++ b/circuits/tests/transaction.rs
@@ -6,12 +6,12 @@
 
 #![cfg(feature = "plonk")]
 
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use rand::{CryptoRng, RngCore};
 
 use dusk_bls12_381::BlsScalar;
-use dusk_jubjub::{JubJubAffine, JubJubScalar, GENERATOR_NUMS_EXTENDED};
+use dusk_jubjub::{GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar};
 use dusk_plonk::prelude::{Compiler, PublicParameters};
 use ff::Field;
 use jubjub_elgamal::Encryption as ElGamal;
@@ -22,7 +22,7 @@ use poseidon_merkle::{Item, Tree};
 
 use phoenix_circuits::{InputNoteInfo, OutputNoteInfo, TxCircuit};
 use phoenix_core::{
-    value_commitment, Note, PublicKey, SecretKey, ViewKey, OUTPUT_NOTES,
+    Note, OUTPUT_NOTES, PublicKey, SecretKey, ViewKey, value_commitment,
 };
 
 #[macro_use]

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Move to edition 2024
 - Move to stable MSRV 1.85
 - Update `dusk-poseidon` to v0.42.0-rc.0
 - Update `jubjub-schnorr` to v0.7.0-rc.0

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "phoenix-core"
 version = "0.34.0"
-edition = "2021"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]
 
 license.workspace = true
 rust-version.workspace = true
+edition.workspace = true
 
 [dependencies]
 rand = { version = "0.8", default-features = false }

--- a/core/src/encryption/aes.rs
+++ b/core/src/encryption/aes.rs
@@ -8,8 +8,8 @@ use dusk_jubjub::JubJubAffine;
 use rand::{CryptoRng, RngCore};
 
 use aes_gcm::{
-    aead::{Aead, AeadCore, KeyInit},
     Aes256Gcm, Key,
+    aead::{Aead, AeadCore, KeyInit},
 };
 
 use hkdf::Hkdf;

--- a/core/src/keys/public.rs
+++ b/core/src/keys/public.rs
@@ -4,7 +4,7 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{keys::hash, SecretKey, StealthAddress, ViewKey};
+use crate::{SecretKey, StealthAddress, ViewKey, keys::hash};
 
 use dusk_jubjub::{JubJubAffine, JubJubExtended, JubJubScalar};
 

--- a/core/src/keys/secret.rs
+++ b/core/src/keys/secret.rs
@@ -4,9 +4,9 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{keys::hash, StealthAddress};
+use crate::{StealthAddress, keys::hash};
 
-use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED};
+use dusk_jubjub::{GENERATOR_EXTENDED, JubJubScalar};
 use ff::Field;
 use jubjub_schnorr::SecretKey as NoteSecretKey;
 use zeroize::Zeroize;

--- a/core/src/keys/view.rs
+++ b/core/src/keys/view.rs
@@ -4,11 +4,11 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use crate::{keys::hash, SecretKey, StealthAddress};
+use crate::{SecretKey, StealthAddress, keys::hash};
 
 use dusk_bytes::{DeserializableSlice, Error, Serializable};
 use dusk_jubjub::{
-    JubJubAffine, JubJubExtended, JubJubScalar, GENERATOR_EXTENDED,
+    GENERATOR_EXTENDED, JubJubAffine, JubJubExtended, JubJubScalar,
 };
 use subtle::{Choice, ConstantTimeEq};
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -39,7 +39,7 @@ pub use stealth_address::StealthAddress;
 pub use transaction::TxSkeleton;
 
 use dusk_jubjub::{
-    JubJubAffine, JubJubScalar, GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED,
+    GENERATOR_EXTENDED, GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar,
 };
 
 /// Use the pedersen commitment scheme to compute a transparent value

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -8,7 +8,7 @@ use core::convert::{TryFrom, TryInto};
 
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
-use dusk_jubjub::{dhke, JubJubAffine, JubJubScalar, GENERATOR_NUMS_EXTENDED};
+use dusk_jubjub::{GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar, dhke};
 use dusk_poseidon::{Domain, Hash};
 use ff::Field;
 use jubjub_elgamal::{DecryptFrom, Encryption as ElGamal};
@@ -16,8 +16,8 @@ use jubjub_schnorr::{PublicKey as NotePublicKey, SecretKey as NoteSecretKey};
 use rand::{CryptoRng, RngCore};
 
 use crate::{
-    aes, transparent_value_commitment, value_commitment, Error, PublicKey,
-    SecretKey, StealthAddress, ViewKey,
+    Error, PublicKey, SecretKey, StealthAddress, ViewKey, aes,
+    transparent_value_commitment, value_commitment,
 };
 
 #[cfg(feature = "rkyv-impl")]

--- a/core/tests/encryption.rs
+++ b/core/tests/encryption.rs
@@ -4,10 +4,10 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_jubjub::{JubJubAffine, JubJubScalar, GENERATOR};
+use dusk_jubjub::{GENERATOR, JubJubAffine, JubJubScalar};
 use phoenix_core::aes;
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 #[test]
 fn test_aes_encrypt_and_decrypt() {

--- a/core/tests/keys.rs
+++ b/core/tests/keys.rs
@@ -8,8 +8,8 @@ use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_jubjub::JubJubScalar;
 use ff::Field;
 use phoenix_core::{Note, PublicKey, SecretKey, ViewKey};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 use zeroize::Zeroize;
 
 #[test]
@@ -54,7 +54,7 @@ fn keys_encoding() {
 
 #[test]
 fn keys_consistency() {
-    use dusk_jubjub::{JubJubScalar, GENERATOR_EXTENDED};
+    use dusk_jubjub::{GENERATOR_EXTENDED, JubJubScalar};
 
     const NOTE_VALUE: u64 = 42;
 

--- a/core/tests/note_test.rs
+++ b/core/tests/note_test.rs
@@ -8,8 +8,8 @@ use dusk_bytes::Serializable;
 use dusk_jubjub::{JubJubAffine, JubJubScalar};
 use ff::Field;
 use phoenix_core::{
-    value_commitment, Error, Note, NoteType, PublicKey, SecretKey, Sender,
-    ViewKey,
+    Error, Note, NoteType, PublicKey, SecretKey, Sender, ViewKey,
+    value_commitment,
 };
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};

--- a/core/tests/serde.rs
+++ b/core/tests/serde.rs
@@ -61,7 +61,7 @@ fn serde_public_key() -> Result<(), Box<dyn std::error::Error>> {
     let pk = PublicKey::from(&sk);
     let ser = assert_canonical_json(
         &pk,
-        "\"nrkRNs188TSAy7LdQcwDfbghZEk3agdT7b7h83ynP6KcFb8ExYvUyE6r3v2yrt2Tie8pybzobLGebF6LapsDnAa\""
+        "\"nrkRNs188TSAy7LdQcwDfbghZEk3agdT7b7h83ynP6KcFb8ExYvUyE6r3v2yrt2Tie8pybzobLGebF6LapsDnAa\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(pk, deser);
@@ -74,7 +74,7 @@ fn serde_secret_key() -> Result<(), Box<dyn std::error::Error>> {
     let sk = SecretKey::random(&mut rng);
     let ser = assert_canonical_json(
         &sk,
-        "\"4VWvwJK79fznAuRZm9qP6Eqv57hLuYGU2PkoJJxYii2C7kquTNQYAygrJuYVLY1vsmVHSLifNtCdcN6dHN69rJKC\""
+        "\"4VWvwJK79fznAuRZm9qP6Eqv57hLuYGU2PkoJJxYii2C7kquTNQYAygrJuYVLY1vsmVHSLifNtCdcN6dHN69rJKC\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(sk, deser);
@@ -88,7 +88,7 @@ fn serde_view_key() -> Result<(), Box<dyn std::error::Error>> {
     let vk = ViewKey::from(&sk);
     let ser = assert_canonical_json(
         &vk,
-        "\"4VWvwJK79fznAuRZm9qP6Eqv57hLuYGU2PkoJJxYii2CB6ZEEiHSgjYzXkaiQaAq7TDr6zEyuqUgpzLRcXfq1pdU\""
+        "\"4VWvwJK79fznAuRZm9qP6Eqv57hLuYGU2PkoJJxYii2CB6ZEEiHSgjYzXkaiQaAq7TDr6zEyuqUgpzLRcXfq1pdU\"",
     )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(vk, deser);
@@ -115,7 +115,9 @@ fn serde_stealth_address() -> Result<(), Box<dyn std::error::Error>> {
     let pk = PublicKey::from(&SecretKey::random(&mut rng));
     let stealth_addr = pk.gen_stealth_address(&scalar);
     let ser = assert_canonical_json(
-        &stealth_addr, "\"nrkRNs188TSAy7LdQcwDfbghZEk3agdT7b7h83ynP6KU2WHtBFqNXSZt9qJwZDZmhWPakFuWRg4m5hRHH2kF5su\"")?;
+        &stealth_addr,
+        "\"nrkRNs188TSAy7LdQcwDfbghZEk3agdT7b7h83ynP6KU2WHtBFqNXSZt9qJwZDZmhWPakFuWRg4m5hRHH2kF5su\"",
+    )?;
     let deser = serde_json::from_str(&ser)?;
     assert_eq!(stealth_addr, deser);
     Ok(())

--- a/core/tests/tx_skeleton.rs
+++ b/core/tests/tx_skeleton.rs
@@ -8,8 +8,8 @@ use dusk_bls12_381::BlsScalar;
 use dusk_jubjub::JubJubScalar;
 use ff::Field;
 use phoenix_core::{Error, Note, PublicKey, SecretKey, TxSkeleton};
-use rand::rngs::StdRng;
 use rand::SeedableRng;
+use rand::rngs::StdRng;
 
 fn output_notes(rng: &mut StdRng) -> [Note; 2] {
     let sender_pk = PublicKey::from(&SecretKey::random(rng));


### PR DESCRIPTION
- Move to edition 2024
- Move to stable MSRV 1.85
- Update `dusk-plonk` to v0.22.0-rc.0
- Update `poseidon-merkle` to v0.9.0-rc.0
- Update `dusk-poseidon` to v0.42.0-rc.0
- Update `jubjub-schnorr` to v0.7.0-rc.0
- Update `jubjub-elgamal` to v0.5.0-rc.0
