### PR TITLE
Bump core to v0.35.0-rc.0 and circuits to v0.7.0-rc.0

### DIFF
--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 
 [dependencies]
 dusk-bytes = "0.1"
-phoenix-core = { version = "0.34", default-features = false, path = "../core" }
+phoenix-core = { version = "0.35.0-rc.0", default-features = false, path = "../core" }
 dusk-bls12_381 = { version = "0.14", default-features = false }
 dusk-jubjub = { version = "0.15", default-features = false }
 poseidon-merkle = "0.9.0-rc.0"

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-circuits"
-version = "0.6.0"
+version = "0.7.0-rc.0"
 repository = "https://github.com/dusk-network/phoenix/circuits"
 description = "Circuit definitions for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "phoenix-core"
-version = "0.34.0"
+version = "0.35.0-rc.0"
 repository = "https://github.com/dusk-network/phoenix/core"
 description = "Core types and functionalities for Phoenix, a privacy-preserving ZKP-based transaction model"
 exclude = [".github/workflows/dusk-ci.yml", ".gitignore"]


### PR DESCRIPTION
## `phoenix-core`
### Fixed

- Fix order-dependent deserialization of `Note` [#274]

### Changed

- Move to edition 2024
- Move to stable MSRV 1.85
- Update `dusk-poseidon` to v0.42.0-rc.0
- Update `jubjub-schnorr` to v0.7.0-rc.0
- Update `jubjub-elgamal` to v0.5.0-rc.0


## `phoenix-circuits`

### Changed

- Move to edition 2024
- Move to stable MSRV 1.85
- Update `dusk-plonk` to v0.22.0-rc.0
- Update `poseidon-merkle` to v0.9.0-rc.0
- Update `dusk-poseidon` to v0.42.0-rc.0
- Update `jubjub-schnorr` to v0.7.0-rc.0
- Update `jubjub-elgamal` to v0.5.0-rc.0
