### PR TITLE
circuits: Bind output encryption to note openings

### DIFF
--- a/circuits/CHANGELOG.md
+++ b/circuits/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an auxiliary proof binding each output's encrypted value and blinder to
+  its public commitment opening [#292]
+
 ## [0.8.1] - 2026-06-15
 
 ### Changed
@@ -146,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `poseidon-merkle` to v0.6 [#179]
 
 <!-- ISSUES -->
+[#292]: https://github.com/dusk-network/phoenix/issues/292
 [#280]: https://github.com/dusk-network/phoenix/issues/280
 [#255]: https://github.com/dusk-network/phoenix/issues/255
 [#235]: https://github.com/dusk-network/phoenix/issues/235

--- a/circuits/Cargo.toml
+++ b/circuits/Cargo.toml
@@ -36,6 +36,7 @@ default = ["plonk"]
 plonk = [
     "dusk-plonk",
     "poseidon-merkle/zk",
+    "dusk-poseidon/encryption",
     "dusk-poseidon/zk",
     "jubjub-schnorr/zk",
     "jubjub-elgamal/zk",

--- a/circuits/README.md
+++ b/circuits/README.md
@@ -9,3 +9,4 @@ This library contains the implementation of the Phoenix-circuits, to prove, in z
 3. Nullification: the nullifier is calculated correctly.
 4. Minting: the value commitment for the newly minted notes are computed correctly.
 5. Balance integrity: the sum of the values of all spent notes is equal to the sum of the values of all minted notes + the gas fee + a deposit, where a deposit refers to funds being transfered to a contract.
+6. Value encryption: an auxiliary proof shows that every encrypted output contains the same value and blinder used for its public commitment.

--- a/circuits/src/lib.rs
+++ b/circuits/src/lib.rs
@@ -12,6 +12,7 @@
 
 #[cfg(feature = "plonk")]
 mod circuit_impl;
+mod output_encryption;
 #[cfg(feature = "plonk")]
 mod sender_enc;
 
@@ -26,6 +27,8 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 extern crate alloc;
 use alloc::vec::Vec;
+
+pub use output_encryption::{OutputEncryptionCircuit, OutputEncryptionInfo};
 
 /// Declaration of the transaction circuit calling the [`gadget`].
 #[derive(Debug, Clone, PartialEq)]

--- a/circuits/src/output_encryption.rs
+++ b/circuits/src/output_encryption.rs
@@ -1,0 +1,305 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+//! Proof that output-note ciphertexts contain their commitment openings.
+
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
+#[cfg(feature = "plonk")]
+use dusk_jubjub::{GENERATOR, GENERATOR_NUMS};
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use phoenix_core::{
+    Note, NoteType, OUTPUT_NOTES, PublicKey, VALUE_ENC_SCALARS,
+};
+#[cfg(feature = "rkyv-impl")]
+use rkyv::{Archive, Deserialize, Serialize};
+
+/// Circuit proving that both output-note payloads encrypt their public
+/// commitment openings.
+///
+/// A verifier must bind every public input to the serialized output notes, and
+/// bind the value commitments to those supplied to the transaction circuit.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct OutputEncryptionCircuit {
+    /// The opening and encryption information for both output notes.
+    pub outputs: [OutputEncryptionInfo; OUTPUT_NOTES],
+}
+
+impl OutputEncryptionCircuit {
+    /// The serialized size of an [`OutputEncryptionCircuit`].
+    pub const SIZE: usize = OUTPUT_NOTES * OutputEncryptionInfo::SIZE;
+}
+
+impl Default for OutputEncryptionCircuit {
+    fn default() -> Self {
+        Self {
+            outputs: core::array::from_fn(|_| OutputEncryptionInfo::default()),
+        }
+    }
+}
+
+impl Serializable<{ OUTPUT_NOTES * OUTPUT_ENCRYPTION_INFO_SIZE }>
+    for OutputEncryptionCircuit
+{
+    type Error = BytesError;
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        for (info, output) in self
+            .outputs
+            .iter()
+            .zip(bytes.chunks_exact_mut(OutputEncryptionInfo::SIZE))
+        {
+            output.copy_from_slice(&info.to_bytes());
+        }
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        let mut reader = &bytes[..];
+        Ok(Self {
+            outputs: [
+                OutputEncryptionInfo::from_reader(&mut reader)?,
+                OutputEncryptionInfo::from_reader(&mut reader)?,
+            ],
+        })
+    }
+}
+
+/// Witnesses and public note fields needed to prove one output encryption.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(
+    feature = "rkyv-impl",
+    derive(Archive, Serialize, Deserialize),
+    archive_attr(derive(bytecheck::CheckBytes))
+)]
+pub struct OutputEncryptionInfo {
+    /// Whether the note exposes or encrypts its opening.
+    pub note_type: NoteType,
+    /// The value committed by the output note.
+    pub value: u64,
+    /// The output note's public value commitment.
+    pub value_commitment: JubJubAffine,
+    /// The blinder opening the public value commitment.
+    pub value_blinder: JubJubScalar,
+    /// The encrypted opening and nonce published by the note.
+    pub value_enc: [BlsScalar; VALUE_ENC_SCALARS],
+    /// The ephemeral point published in the note's stealth address.
+    pub R: JubJubAffine,
+    /// The receiver's private circuit input `A` used to derive the encryption
+    /// key. Its relation to the stealth address is intentionally not disclosed
+    /// by the output note.
+    pub receiver_A: JubJubAffine,
+    /// The ephemeral scalar returned by [`Note::new_with_ephemeral`].
+    pub encryption_secret: JubJubScalar,
+}
+
+impl OutputEncryptionInfo {
+    /// Construct proof inputs from a note and the private values used to create
+    /// it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`phoenix_core::Error::InvalidData`] when the note's encrypted
+    /// fields are not canonically encoded scalars.
+    pub fn new(
+        note: &Note,
+        receiver_pk: &PublicKey,
+        value: u64,
+        value_blinder: JubJubScalar,
+        encryption_secret: JubJubScalar,
+    ) -> Result<Self, phoenix_core::Error> {
+        Ok(Self {
+            note_type: note.note_type(),
+            value,
+            value_commitment: *note.value_commitment(),
+            value_blinder,
+            value_enc: note.value_enc_scalars()?,
+            R: JubJubAffine::from(note.stealth_address().R()),
+            receiver_A: JubJubAffine::from(receiver_pk.A()),
+            encryption_secret,
+        })
+    }
+}
+
+impl Default for OutputEncryptionInfo {
+    fn default() -> Self {
+        Self {
+            note_type: NoteType::Transparent,
+            value: 0,
+            value_commitment: JubJubAffine::default(),
+            value_blinder: JubJubScalar::default(),
+            value_enc: [BlsScalar::default(); VALUE_ENC_SCALARS],
+            R: JubJubAffine::default(),
+            receiver_A: JubJubAffine::default(),
+            encryption_secret: JubJubScalar::default(),
+        }
+    }
+}
+
+const OUTPUT_ENCRYPTION_INFO_SIZE: usize = u8::SIZE
+    + u64::SIZE
+    + JubJubAffine::SIZE
+    + JubJubScalar::SIZE
+    + VALUE_ENC_SCALARS * BlsScalar::SIZE
+    + 2 * JubJubAffine::SIZE
+    + JubJubScalar::SIZE;
+
+impl Serializable<OUTPUT_ENCRYPTION_INFO_SIZE> for OutputEncryptionInfo {
+    type Error = BytesError;
+
+    fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut bytes = [0u8; Self::SIZE];
+        let mut offset = 0;
+
+        bytes[offset] = self.note_type as u8;
+        offset += u8::SIZE;
+        bytes[offset..offset + u64::SIZE]
+            .copy_from_slice(&self.value.to_bytes());
+        offset += u64::SIZE;
+        bytes[offset..offset + JubJubAffine::SIZE]
+            .copy_from_slice(&self.value_commitment.to_bytes());
+        offset += JubJubAffine::SIZE;
+        bytes[offset..offset + JubJubScalar::SIZE]
+            .copy_from_slice(&self.value_blinder.to_bytes());
+        offset += JubJubScalar::SIZE;
+        for cipher in self.value_enc {
+            bytes[offset..offset + BlsScalar::SIZE]
+                .copy_from_slice(&cipher.to_bytes());
+            offset += BlsScalar::SIZE;
+        }
+        bytes[offset..offset + JubJubAffine::SIZE]
+            .copy_from_slice(&self.R.to_bytes());
+        offset += JubJubAffine::SIZE;
+        bytes[offset..offset + JubJubAffine::SIZE]
+            .copy_from_slice(&self.receiver_A.to_bytes());
+        offset += JubJubAffine::SIZE;
+        bytes[offset..offset + JubJubScalar::SIZE]
+            .copy_from_slice(&self.encryption_secret.to_bytes());
+
+        bytes
+    }
+
+    fn from_bytes(bytes: &[u8; Self::SIZE]) -> Result<Self, Self::Error> {
+        let mut reader = &bytes[..];
+
+        let note_type = u8::from_reader(&mut reader)?
+            .try_into()
+            .map_err(|_| BytesError::InvalidData)?;
+        let value = u64::from_reader(&mut reader)?;
+        let value_commitment = JubJubAffine::from_reader(&mut reader)?;
+        let value_blinder = JubJubScalar::from_reader(&mut reader)?;
+        let mut value_enc = [BlsScalar::default(); VALUE_ENC_SCALARS];
+        for cipher in &mut value_enc {
+            *cipher = BlsScalar::from_reader(&mut reader)?;
+        }
+        let R = JubJubAffine::from_reader(&mut reader)?;
+        let receiver_A = JubJubAffine::from_reader(&mut reader)?;
+        let encryption_secret = JubJubScalar::from_reader(&mut reader)?;
+
+        Ok(Self {
+            note_type,
+            value,
+            value_commitment,
+            value_blinder,
+            value_enc,
+            R,
+            receiver_A,
+            encryption_secret,
+        })
+    }
+}
+
+#[cfg(feature = "plonk")]
+use dusk_plonk::prelude::{Circuit, Composer, Error as PlonkError, Witness};
+#[cfg(feature = "plonk")]
+use dusk_poseidon::encrypt_gadget;
+
+#[cfg(feature = "plonk")]
+impl Circuit for OutputEncryptionCircuit {
+    /// Prove, for both outputs, that:
+    ///
+    /// - the public commitment opens to the private value and blinder;
+    /// - the public ephemeral point is `r·G`;
+    /// - an obfuscated payload is the authenticated encryption of that same
+    ///   opening under `r·A`; or
+    /// - a transparent payload is the canonical cleartext encoding.
+    ///
+    /// The public inputs for each output are, in order, its value commitment,
+    /// note type, encrypted opening, and ephemeral point `R`.
+    fn circuit(&self, composer: &mut Composer) -> Result<(), PlonkError> {
+        for output in &self.outputs {
+            let value = composer.append_witness(output.value);
+            composer.component_range::<32>(value);
+            let value_blinder = composer.append_witness(output.value_blinder);
+
+            let expected_commitment =
+                composer.append_public_point(output.value_commitment);
+            let value_point =
+                composer.component_mul_generator(value, GENERATOR)?;
+            let blinder_point = composer
+                .component_mul_generator(value_blinder, GENERATOR_NUMS)?;
+            let commitment =
+                composer.component_add_point(value_point, blinder_point);
+            composer.assert_equal_point(expected_commitment, commitment);
+
+            let note_type = composer
+                .append_public(BlsScalar::from(output.note_type as u64));
+            composer.component_boolean(note_type);
+            let value_enc =
+                output.value_enc.map(|value| composer.append_public(value));
+            let R = composer.append_public_point(output.R);
+
+            let encryption_secret =
+                composer.append_witness(output.encryption_secret);
+            let expected_R = composer
+                .component_mul_generator(encryption_secret, GENERATOR)?;
+            composer.assert_equal_point(R, expected_R);
+
+            let receiver_A = composer.append_point(output.receiver_A);
+            let shared_secret =
+                composer.component_mul_point(encryption_secret, receiver_A);
+            let encrypted: [Witness; 3] = encrypt_gadget(
+                composer,
+                [value, value_blinder],
+                &shared_secret,
+                &value_enc[3],
+            )
+            .expect("two-element value encryption should be valid")
+            .try_into()
+            .expect("two elements produce three cipher elements");
+
+            let clear = [value, Composer::ZERO, Composer::ZERO];
+            for ((public, encrypted), clear) in
+                value_enc[..3].iter().zip(encrypted).zip(clear)
+            {
+                let expected =
+                    composer.component_select(note_type, encrypted, clear);
+                composer.assert_equal(*public, expected);
+            }
+
+            enforce_zero_for_transparent(composer, note_type, value_enc[3]);
+            enforce_zero_for_transparent(composer, note_type, value_blinder);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "plonk")]
+fn enforce_zero_for_transparent(
+    composer: &mut Composer,
+    note_type: Witness,
+    value: Witness,
+) {
+    let selected = composer.component_select(note_type, value, Composer::ZERO);
+    composer.assert_equal(value, selected);
+}

--- a/circuits/tests/output_encryption.rs
+++ b/circuits/tests/output_encryption.rs
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+#![cfg(feature = "plonk")]
+
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::Serializable;
+use dusk_jubjub::{JubJubAffine, JubJubScalar};
+use dusk_plonk::prelude::{Circuit, Compiler};
+use ff::Field;
+use phoenix_circuits::{OutputEncryptionCircuit, OutputEncryptionInfo};
+use phoenix_core::{Note, NoteType, PublicKey, SecretKey, value_commitment};
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+#[allow(dead_code)]
+mod common;
+use common::{LABEL, load_production_crs};
+
+fn output(
+    rng: &mut StdRng,
+    sender_pk: &PublicKey,
+    receiver_pk: &PublicKey,
+    note_type: NoteType,
+    value: u64,
+) -> OutputEncryptionInfo {
+    let value_blinder = match note_type {
+        NoteType::Transparent => JubJubScalar::zero(),
+        NoteType::Obfuscated => JubJubScalar::random(&mut *rng),
+    };
+    let sender_blinder = [
+        JubJubScalar::random(&mut *rng),
+        JubJubScalar::random(&mut *rng),
+    ];
+    let (note, encryption_secret) = Note::new_with_ephemeral(
+        rng,
+        note_type,
+        sender_pk,
+        receiver_pk,
+        value,
+        value_blinder,
+        sender_blinder,
+    );
+
+    OutputEncryptionInfo::new(
+        &note,
+        receiver_pk,
+        value,
+        value_blinder,
+        encryption_secret,
+    )
+    .expect("the note constructor emits canonical scalars")
+}
+
+fn expected_public_inputs(circuit: &OutputEncryptionCircuit) -> Vec<BlsScalar> {
+    let mut inputs = Vec::new();
+    for output in &circuit.outputs {
+        inputs.push(output.value_commitment.get_u());
+        inputs.push(output.value_commitment.get_v());
+        inputs.push(BlsScalar::from(output.note_type as u64));
+        inputs.extend(output.value_enc);
+        inputs.push(output.R.get_u());
+        inputs.push(output.R.get_v());
+    }
+    inputs
+}
+
+#[test]
+fn binds_output_ciphertexts_to_their_commitment_openings() {
+    let mut rng = StdRng::seed_from_u64(0xc1f3);
+    let pp = load_production_crs();
+    let (prover, verifier) =
+        Compiler::compile::<OutputEncryptionCircuit>(&pp, LABEL)
+            .expect("the auxiliary circuit must fit the production CRS");
+
+    assert!(OutputEncryptionCircuit::default().size() < 1 << 17);
+
+    let sender_pk = PublicKey::from(&SecretKey::random(&mut rng));
+    let receiver_pk = PublicKey::from(&SecretKey::random(&mut rng));
+    let honest = OutputEncryptionCircuit {
+        outputs: [
+            output(
+                &mut rng,
+                &sender_pk,
+                &receiver_pk,
+                NoteType::Obfuscated,
+                10,
+            ),
+            output(&mut rng, &sender_pk, &sender_pk, NoteType::Transparent, 5),
+        ],
+    };
+
+    assert_eq!(
+        honest,
+        OutputEncryptionCircuit::from_bytes(&honest.to_bytes())
+            .expect("the auxiliary circuit should round-trip")
+    );
+    let (proof, public_inputs) = prover
+        .prove(&mut rng, &honest)
+        .expect("honest encrypted and transparent outputs should prove");
+    assert_eq!(public_inputs, expected_public_inputs(&honest));
+    verifier
+        .verify(&proof, &public_inputs)
+        .expect("honest output encryptions should verify");
+
+    let committed_value = 10;
+    let committed_blinder = JubJubScalar::random(&mut rng);
+    let encrypted_value = 1_000;
+    let encrypted_blinder = JubJubScalar::random(&mut rng);
+    let sender_blinder = [
+        JubJubScalar::random(&mut rng),
+        JubJubScalar::random(&mut rng),
+    ];
+    let (encrypted_note, encryption_secret) = Note::new_with_ephemeral(
+        &mut rng,
+        NoteType::Obfuscated,
+        &sender_pk,
+        &receiver_pk,
+        encrypted_value,
+        encrypted_blinder,
+        sender_blinder,
+    );
+    let mut encoded = encrypted_note.to_bytes();
+    encoded[1..1 + JubJubAffine::SIZE].copy_from_slice(
+        &value_commitment(committed_value, committed_blinder).to_bytes(),
+    );
+    let malformed_note =
+        Note::from_bytes(&encoded).expect("the individual fields are valid");
+    let malformed = OutputEncryptionInfo::new(
+        &malformed_note,
+        &receiver_pk,
+        committed_value,
+        committed_blinder,
+        encryption_secret,
+    )
+    .expect("the ciphertext fields are canonical");
+
+    let malformed_circuit = OutputEncryptionCircuit {
+        outputs: [malformed, honest.outputs[1].clone()],
+    };
+    assert!(
+        prover.prove(&mut rng, &malformed_circuit).is_err(),
+        "a ciphertext containing a different opening was proved"
+    );
+
+    let mut tampered = honest.clone();
+    tampered.outputs[0].value_enc[0] += BlsScalar::one();
+    assert!(
+        prover.prove(&mut rng, &tampered).is_err(),
+        "a tampered ciphertext was proved"
+    );
+
+    let mut noncanonical_transparent = honest.clone();
+    noncanonical_transparent.outputs[1].value_enc[1] = BlsScalar::one();
+    assert!(
+        prover.prove(&mut rng, &noncanonical_transparent).is_err(),
+        "a non-canonical transparent payload was proved"
+    );
+
+    let mut wrong_receiver = honest.clone();
+    let other_receiver = PublicKey::from(&SecretKey::random(&mut rng));
+    wrong_receiver.outputs[0].receiver_A =
+        JubJubAffine::from(other_receiver.A());
+    assert!(
+        prover.prove(&mut rng, &wrong_receiver).is_err(),
+        "a ciphertext under a different receiver key was proved"
+    );
+
+    let mut wrong_ephemeral = honest;
+    wrong_ephemeral.outputs[0].encryption_secret += JubJubScalar::one();
+    assert!(
+        prover.prove(&mut rng, &wrong_ephemeral).is_err(),
+        "an encryption secret inconsistent with R was proved"
+    );
+}

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Replace output-value AES encryption with circuit-friendly authenticated
+  Poseidon encryption, changing the serialized note format [#292]
 - Update `dusk-jubjub` to v0.15.2 for its torsion-rejecting point decoder [#288]
 
 ## [0.35.1] - 2026-06-15
@@ -455,6 +457,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonical implementation shielded by feature.
 
 <!-- ISSUES -->
+[#292]: https://github.com/dusk-network/phoenix/issues/292
 [#288]: https://github.com/dusk-network/phoenix/issues/288
 [#274]: https://github.com/dusk-network/phoenix/issues/274
 [#261]: https://github.com/dusk-network/phoenix/issues/261

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ dusk-bls12_381 = { version = "0.14", default-features = false }
 dusk-jubjub = { version = "0.15.2", default-features = false, features = [
     "zeroize",
 ] }
-dusk-poseidon = "0.42.0-rc.0"
+dusk-poseidon = { version = "0.42.0-rc.0", features = ["encryption"] }
 jubjub-schnorr = "0.7.0-rc.0"
 jubjub-elgamal = "0.5.0"
 subtle = { version = "2.6", default-features = false }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,7 +34,10 @@ pub use keys::hash;
 pub use keys::public::PublicKey;
 pub use keys::secret::SecretKey;
 pub use keys::view::ViewKey;
-pub use note::{Note, NoteType, Sender, VALUE_ENC_SIZE as NOTE_VAL_ENC_SIZE};
+pub use note::{
+    Note, NoteType, Sender, VALUE_ENC_SCALARS,
+    VALUE_ENC_SIZE as NOTE_VAL_ENC_SIZE,
+};
 pub use stealth_address::StealthAddress;
 #[cfg(feature = "alloc")]
 /// Transaction Skeleton used by the phoenix transaction model

--- a/core/src/note.rs
+++ b/core/src/note.rs
@@ -9,7 +9,7 @@ use core::convert::{TryFrom, TryInto};
 use dusk_bls12_381::BlsScalar;
 use dusk_bytes::{DeserializableSlice, Error as BytesError, Serializable};
 use dusk_jubjub::{GENERATOR_NUMS_EXTENDED, JubJubAffine, JubJubScalar, dhke};
-use dusk_poseidon::{Domain, Hash};
+use dusk_poseidon::{Domain, Hash, decrypt, encrypt};
 use ff::Field;
 use jubjub_elgamal::{DecryptFrom, Encryption as ElGamal};
 use jubjub_schnorr::{PublicKey as NotePublicKey, SecretKey as NoteSecretKey};
@@ -19,18 +19,31 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::stealth_address::affine_from_slice_legacy_compat;
 use crate::{
-    Error, PublicKey, SecretKey, StealthAddress, ViewKey, aes,
+    Error, PublicKey, SecretKey, StealthAddress, ViewKey,
     transparent_value_commitment, value_commitment,
 };
 
 /// Blinder used for transparent notes.
 pub(crate) const TRANSPARENT_BLINDER: JubJubScalar = JubJubScalar::zero();
 
-/// Size of the Phoenix notes plaintext: value (8 bytes) + blinder (32 bytes)
-pub(crate) const PLAINTEXT_SIZE: usize = 40;
+/// Number of scalars in an encrypted Phoenix note opening: two encrypted
+/// message elements, an authentication tag, and a nonce.
+pub const VALUE_ENC_SCALARS: usize = 4;
 
-/// Size of the Phoenix notes value_enc
-pub const VALUE_ENC_SIZE: usize = PLAINTEXT_SIZE + aes::ENCRYPTION_EXTRA_SIZE;
+/// Size of the Phoenix notes value encryption.
+pub const VALUE_ENC_SIZE: usize = VALUE_ENC_SCALARS * BlsScalar::SIZE;
+
+fn encode_value_encryption(
+    scalars: [BlsScalar; VALUE_ENC_SCALARS],
+) -> [u8; VALUE_ENC_SIZE] {
+    let mut bytes = [0u8; VALUE_ENC_SIZE];
+    for (scalar, output) in
+        scalars.iter().zip(bytes.chunks_exact_mut(BlsScalar::SIZE))
+    {
+        output.copy_from_slice(&scalar.to_bytes());
+    }
+    bytes
+}
 
 /// The types of a Note
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -111,6 +124,33 @@ impl Note {
         value_blinder: JubJubScalar,
         sender_blinder: [JubJubScalar; 2],
     ) -> Self {
+        Self::new_with_ephemeral(
+            rng,
+            note_type,
+            sender_pk,
+            receiver_pk,
+            value,
+            value_blinder,
+            sender_blinder,
+        )
+        .0
+    }
+
+    /// Creates a new Phoenix output note and returns the ephemeral scalar used
+    /// to derive its stealth address and value-encryption key.
+    ///
+    /// The scalar is required by the output-encryption circuit to prove that
+    /// the encrypted opening and the public value commitment use the same
+    /// value and blinder.
+    pub fn new_with_ephemeral<R: RngCore + CryptoRng>(
+        rng: &mut R,
+        note_type: NoteType,
+        sender_pk: &PublicKey,
+        receiver_pk: &PublicKey,
+        value: u64,
+        value_blinder: JubJubScalar,
+        sender_blinder: [JubJubScalar; 2],
+    ) -> (Self, JubJubScalar) {
         let r = JubJubScalar::random(&mut *rng);
         let stealth_address = receiver_pk.gen_stealth_address(&r);
 
@@ -120,38 +160,44 @@ impl Note {
         let pos = u64::MAX;
 
         let value_enc = match note_type {
-            NoteType::Transparent => {
-                let mut value_enc = [0u8; VALUE_ENC_SIZE];
-                value_enc[..u64::SIZE].copy_from_slice(&value.to_bytes());
-
-                value_enc
-            }
+            NoteType::Transparent => encode_value_encryption([
+                BlsScalar::from(value),
+                BlsScalar::zero(),
+                BlsScalar::zero(),
+                BlsScalar::zero(),
+            ]),
             NoteType::Obfuscated => {
                 let shared_secret = dhke(&r, receiver_pk.A());
-                let value_blinder = BlsScalar::from(value_blinder);
+                let nonce = BlsScalar::random(&mut *rng);
+                let message =
+                    [BlsScalar::from(value), BlsScalar::from(value_blinder)];
+                let cipher: [BlsScalar; 3] =
+                    encrypt(message, &shared_secret, &nonce)
+                        .expect("value encryption should succeed")
+                        .try_into()
+                        .expect("two elements produce three cipher elements");
 
-                let mut plaintext = value.to_bytes().to_vec();
-                plaintext.append(&mut value_blinder.to_bytes().to_vec());
-
-                let salt = stealth_address.to_bytes();
-
-                aes::encrypt(&shared_secret, &salt, &plaintext, rng)
-                    .expect("Encrypted correctly.")
+                encode_value_encryption([
+                    cipher[0], cipher[1], cipher[2], nonce,
+                ])
             }
         };
 
-        Note {
-            note_type,
-            value_commitment,
-            stealth_address,
-            pos,
-            value_enc,
-            sender: Sender::encrypt(
-                stealth_address.note_pk(),
-                sender_pk,
-                &sender_blinder,
-            ),
-        }
+        (
+            Note {
+                note_type,
+                value_commitment,
+                stealth_address,
+                pos,
+                value_enc,
+                sender: Sender::encrypt(
+                    stealth_address.note_pk(),
+                    sender_pk,
+                    &sender_blinder,
+                ),
+            },
+            r,
+        )
     }
 
     /// Creates a new transparent note
@@ -191,8 +237,12 @@ impl Note {
 
         let pos = u64::MAX;
 
-        let mut value_enc = [0u8; VALUE_ENC_SIZE];
-        value_enc[..u64::SIZE].copy_from_slice(&value.to_bytes());
+        let value_enc = encode_value_encryption([
+            BlsScalar::from(value),
+            BlsScalar::zero(),
+            BlsScalar::zero(),
+            BlsScalar::zero(),
+        ]);
 
         Note {
             note_type: NoteType::Transparent,
@@ -315,24 +365,44 @@ impl Note {
         let R = self.stealth_address.R();
         let shared_secret = dhke(vk.a(), R);
 
-        let salt = self.stealth_address.to_bytes();
+        let value_enc = self.value_enc_scalars()?;
+        let plaintext: [BlsScalar; 2] =
+            decrypt(&value_enc[..3], &shared_secret, &value_enc[3])
+                .map_err(|_| Error::InvalidEncryption)?
+                .try_into()
+                .map_err(|_| Error::InvalidData)?;
 
-        let dec_plaintext: [u8; PLAINTEXT_SIZE] =
-            aes::decrypt(&shared_secret, &salt, &self.value_enc)?;
+        let value_bytes = plaintext[0].to_bytes();
+        let value = u64::from_slice(&value_bytes[..u64::SIZE])?;
+        if plaintext[0] != BlsScalar::from(value) {
+            return Err(Error::InvalidData);
+        }
 
-        let value = u64::from_slice(&dec_plaintext[..u64::SIZE])?;
-
-        // Converts the BLS Scalar into a JubJub Scalar.
-        // If the `vk` is wrong it might fails since the resulting BLS Scalar
-        // might not fit into a JubJub Scalar.
-        let value_blinder =
-            match JubJubScalar::from_slice(&dec_plaintext[u64::SIZE..])?.into()
-            {
-                Some(scalar) => scalar,
-                None => return Err(Error::InvalidData),
-            };
+        let value_blinder = Option::<JubJubScalar>::from(
+            JubJubScalar::from_bytes(&plaintext[1].to_bytes()),
+        )
+        .ok_or(Error::InvalidData)?;
 
         Ok((value, value_blinder))
+    }
+
+    /// Decode the value encryption into three cipher scalars and its nonce.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidData`] if any field is not canonically encoded.
+    pub fn value_enc_scalars(
+        &self,
+    ) -> Result<[BlsScalar; VALUE_ENC_SCALARS], Error> {
+        let mut scalars = [BlsScalar::zero(); VALUE_ENC_SCALARS];
+        for (bytes, scalar) in self
+            .value_enc
+            .chunks_exact(BlsScalar::SIZE)
+            .zip(&mut scalars)
+        {
+            *scalar = BlsScalar::from_slice(bytes)?;
+        }
+        Ok(scalars)
     }
 
     /// Create a unique nullifier for the note

--- a/core/tests/note_test.rs
+++ b/core/tests/note_test.rs
@@ -4,7 +4,8 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use dusk_bytes::Serializable;
+use dusk_bls12_381::BlsScalar;
+use dusk_bytes::{DeserializableSlice, Serializable};
 use dusk_jubjub::{
     Fq, GENERATOR_EXTENDED, JubJubAffine, JubJubExtended, JubJubScalar,
 };
@@ -126,6 +127,45 @@ fn obfuscated_note() -> Result<(), Error> {
             .decrypt(&receiver_sk.gen_note_sk(note.stealth_address()))?
     );
     assert_eq!(note, Note::from_bytes(&note.to_bytes())?);
+
+    Ok(())
+}
+
+#[test]
+fn obfuscated_note_rejects_tampered_authentication_tag() -> Result<(), Error> {
+    let mut rng = StdRng::seed_from_u64(0xc1f3);
+
+    let sender_pk = PublicKey::from(&SecretKey::random(&mut rng));
+    let receiver_sk = SecretKey::random(&mut rng);
+    let receiver_pk = PublicKey::from(&receiver_sk);
+    let receiver_vk = ViewKey::from(&receiver_sk);
+    let value_blinder = JubJubScalar::random(&mut rng);
+    let sender_blinder = [
+        JubJubScalar::random(&mut rng),
+        JubJubScalar::random(&mut rng),
+    ];
+    let note = Note::obfuscated(
+        &mut rng,
+        &sender_pk,
+        &receiver_pk,
+        25,
+        value_blinder,
+        sender_blinder,
+    );
+
+    let mut bytes = note.to_bytes();
+    let value_enc_offset =
+        1 + JubJubAffine::SIZE + StealthAddress::SIZE + u64::SIZE;
+    let tag_offset = value_enc_offset + 2 * BlsScalar::SIZE;
+    let mut tag = BlsScalar::from_slice(
+        &bytes[tag_offset..tag_offset + BlsScalar::SIZE],
+    )?;
+    tag += BlsScalar::one();
+    bytes[tag_offset..tag_offset + BlsScalar::SIZE]
+        .copy_from_slice(&tag.to_bytes());
+
+    let tampered = Note::from_bytes(&bytes)?;
+    assert!(tampered.value(Some(&receiver_vk)).is_err());
 
     Ok(())
 }

--- a/core/tests/serde/note.json
+++ b/core/tests/serde/note.json
@@ -3,7 +3,7 @@
     "value_commitment": "1b32e8cda88981d21c7fbfa0ce6827b1826c76d0266f7dff8617af9e43814919",
     "stealth_address": "5xypMFFDSDtAeY7wJTfYc3UQkiHFAoYhWY6Ew2s5m43FfafM66zcsoxgBdLEYUki2KxbG9o4ikjzwzmxpeLfv8Po",
     "pos": "18446744073709551615",
-    "value_enc": "0aa442f45be6ace8b98ce8eba1580f280a82dc8454bfa3166500ab9414d8ad0b6f43da0f1e7049f5dd71f9c013e2c6584286cc88858a3f38670768a1b223eaac405882a9",
+    "value_enc": "dabdae55731e88c02fafe1b4af4ae183dc720f74c0204062a82a6c508390744b585219537262bc7226a647fb7a20705c5d5d5075cfcc321989a9b52e5648b65dd56694df71766c849b428d253fe5a57a6708328256e7b4f7be4dfe29bc44443645c1296b7e02fc0e3e6e57bca99025bf45b3ef10bbe15b86b9518df86f50154f",
     "sender": {
         "Encryption": [
             [

--- a/core/tests/serde/tx_skeleton.json
+++ b/core/tests/serde/tx_skeleton.json
@@ -13,7 +13,7 @@
             "value_commitment": "1b32e8cda88981d21c7fbfa0ce6827b1826c76d0266f7dff8617af9e43814919",
             "stealth_address": "5f5jAMNt2kcUaUXZkZTkTNTAtK7MMgButUXYcCofMiYH88cLp8B8ocwih3iP54JaEeChDgScPiwVvxbF6DJyNFws",
             "pos": "18446744073709551615",
-            "value_enc": "0788aeecb15dcada122f5c4068d9ac73208e6a3298f10243f4d055978f49fbc757ed76b704933f447a4cb56ff1c5b05e126263a5784d7e0db6013a4922df55d29e5ff87e",
+            "value_enc": "d92688987c158f3eb9adef935bced353c81e036546f2b0b2bf7f8aee9b71c454a548c54e743fa911af03f0908423fc3ed07e77a5103f14af76e817b1d9582936e94e232c3b8d43a9772c46d3e15e10caa402f4b1b0bb41010262cc36265b084215926c672126064e464814d52cdf3fb8874f5c09cc8663467fb567821d375032",
             "sender": {
                 "Encryption": [
                     [
@@ -30,23 +30,23 @@
         {
             "note_type": "Obfuscated",
             "value_commitment": "1b32e8cda88981d21c7fbfa0ce6827b1826c76d0266f7dff8617af9e43814919",
-            "stealth_address": "48Qy4vHWBnm9Qpqkreeypv6sXYFgk5HHAoygZ9mbmJJdGWtchDGXswNCqFL9MXS4hZq6aqSdFmKb6vvrB3kv57EQ",
+            "stealth_address": "2BCwvrkVPSPkUGCAhr2nJjYP8BKw3EUiRU7kFGddAvL7GgqpK73om3uHvC7pYVC8h4fxAo3dKKKvZ2pD5F9A9xr6",
             "pos": "18446744073709551615",
-            "value_enc": "43b20fbaf4c96d9bc68a175065f3b3c05bbe27cd8c2f41567326e407c20d0a884e2c5e766c41395205e115630b0bb4606847b0d1c09457acab5a94e93673d3c402aed3c0",
+            "value_enc": "e9626a4b029e3ed19617fe56e20d39bf0786c0e5d9ac130cbc487aa99b1a2a1bebc4ce27eb36e6a55757832998119fdec3ff85437e2b8b817e0741809c99f26b2b6c4b5d163924ea1d6953a04e5f5b48208e1c4fc9bebcf18100036688278d14f361898e80acfbafcae89da8d80a0d753e66463f3f71d71263d0600cdf4c0b3b",
             "sender": {
                 "Encryption": [
                     [
                         "391d595ec6366e6f7dfd01198b00d0c1811c6c826066cf88733e4ddfa8933b58",
-                        "8f3aecf39572005f080fb2bb7d9b907376f36384de83e2f87872fd3719378315"
+                        "b71a2a0e89b23a7044679f04401e91f674cdf4234acdf3119c78e91f0f5b0446"
                     ],
                     [
                         "8fae70481bf1c5e580c450e5a1483f4d7757d1c99dad3dd3adbbaf35ccf70ed7",
-                        "28b9f4b744e0e572b4946d2229fb1c238946abd158d30bf1e124e2778a04ca21"
+                        "a1756ccda8634920db3d97ac845ca1f20072f0094de461a5e8ab56e9908f9f80"
                     ]
                 ]
             }
         }
     ],
-    "max_fee": "622",
-    "deposit": "707"
+    "max_fee": "739",
+    "deposit": "678"
 }


### PR DESCRIPTION
Resolves #292.

## Summary

- replace the AES output-opening payload with circuit-friendly authenticated Poseidon encryption;
- retain the stealth-address ephemeral scalar as a private prover input;
- add one auxiliary proof covering both output notes, binding each public ciphertext, note type, commitment and `R` to the same private value, blinder and encryption key;
- keep the existing transfer circuit and all deployed transfer verifier data unchanged.

## Why an auxiliary proof

Adding the constraints directly to `TxCircuit` increased the 4-input circuit from 128,296 to 136,878 gates, which no longer fits the production CRS. The separate circuit is 9,662 gates, fits the current CRS comfortably, and lets every existing 1/2 through 4/2 transfer verifier remain valid.

The trade-off is one additional PLONK proof. Its serialized size is 1,008 bytes. Together with the larger ciphertexts (56 to 128 bytes per note), this adds 1,152 bytes to a two-output transaction before any downstream envelope changes.

## Compatibility and activation

This is intentionally a draft. It changes the serialized note format and is not historically compatible by itself. Rusk still needs a versioned activation that:

- decodes the old and new note formats at the appropriate protocol versions;
- carries and verifies the auxiliary proof;
- derives all auxiliary public inputs from the serialized outputs;
- installs the new auxiliary verifier data behind the same gate.

The legacy stealth-address derivation uses a hash without a circuit gadget. The auxiliary circuit therefore keeps the receiver's `A` private and proves encryption under `r·A` with public `R = r·G`, but does not additionally constrain `A` to the legacy `note_pk`. A sender can deliberately create an output the intended receiver cannot decrypt, effectively burning it, but cannot use this proof to bind the public ciphertext to a different opening under the supplied key.

## Validation

- reproduced the original behavior: the current transfer circuit accepts a commitment to 10 alongside a payload encrypting 1,000;
- the auxiliary proof rejects that exact mismatch;
- rejects ciphertext tampering, a non-canonical transparent payload, a different receiver key, and an encryption secret inconsistent with `R`;
- proves and verifies mixed honest obfuscated/transparent outputs;
- pins the exact public-input order and circuit serialization round-trip;
- all four existing deployed-verifier-data tests still pass;
- `make test`, `make cq`, `make test-no-std`, `make no-std`, and documentation generation pass.

Local release timings on an Intel Ultra 9 275HX under WSL2/ext4:

- production CRS load: 10.751 s;
- auxiliary circuit compilation: 7.148 s;
- auxiliary proof generation: 5.969 s;
- auxiliary proof verification: 5 ms;
- complete repository test suite: 272.93 s.
